### PR TITLE
Implementing Register Transfers instructions

### DIFF
--- a/m6502/processor.py
+++ b/m6502/processor.py
@@ -802,3 +802,43 @@ class Processor:
             self.fetch_word(),
             self.reg_y
         )
+
+    def ins_tax_imp(self) -> None:
+        """
+        TAX - Transfer Accumulator to X.
+
+        :return: None
+        """
+        self.reg_x = self.read_register_a()
+        self.evaluate_flag_z(self.reg_x)
+        self.evaluate_flag_n(self.reg_x)
+
+    def ins_tay_imp(self) -> None:
+        """
+        TAY - Transfer Accumulator to Y.
+
+        :return: None
+        """
+        self.reg_y = self.read_register_a()
+        self.evaluate_flag_z(self.reg_y)
+        self.evaluate_flag_n(self.reg_y)
+
+    def ins_txa_imp(self) -> None:
+        """
+        TXA - Transfer Register X to Accumulator.
+
+        :return: None
+        """
+        self.reg_a = self.read_register_x()
+        self.evaluate_flag_z(self.reg_a)
+        self.evaluate_flag_n(self.reg_a)
+
+    def ins_tya_imp(self) -> None:
+        """
+        TYA - Transfer Register Y to Accumulator.
+
+        :return: None
+        """
+        self.reg_a = self.read_register_y()
+        self.evaluate_flag_z(self.reg_a)
+        self.evaluate_flag_n(self.reg_a)

--- a/tests/test_cpu_ins_tax.py
+++ b/tests/test_cpu_ins_tax.py
@@ -1,0 +1,67 @@
+"""
+TAX - Transfer Accumulator to X.
+
+X = A
+
+Copies the current contents of the accumulator into the X register and sets
+the zero and negative flags as appropriate.
+
+Processor Status after use:
+
++------+-------------------+--------------------------+
+| Flag | Description       | State                    |
++======+===================+==========================+
+|  C   | Carry Flag        | Not affected             |
++------+-------------------+--------------------------+
+|  Z   | Zero Flag         | Set is X = 0             |
++------+-------------------+--------------------------+
+|  I   | Interrupt Disable | Not affected             |
++------+-------------------+--------------------------+
+|  D   | Decimal Mode Flag | Not affected             |
++------+-------------------+--------------------------+
+|  B   | Break Command     | Not affected             |
++------+-------------------+--------------------------+
+|  V   | Overflow Flag     | Not affected             |
++------+-------------------+--------------------------+
+|  N   | Negative Flag     | Set if bit 7 of X is set |
++------+-------------------+--------------------------+
+
++-----------------+--------+-------+--------+
+| Addressing Mode | Opcode | Bytes | Cycles |
++=================+========+=======+========+
+| Implied         |  0xAA  |   1   |   2    |
++-----------------+--------+-------+--------+
+
+See also: TXA
+"""
+import pytest
+import m6502
+
+
+@pytest.mark.parametrize(
+    "value, flag_n, flag_z", [
+        (0x0F, False, False),
+        (0x00, False, True),
+        (0xF0, True, False),
+    ])
+def test_cpu_ins_tax_imm(value: int, flag_n: bool, flag_z: bool) -> None:
+    """
+    Transfer Accumulator, Implied.
+
+    return: None
+    """
+    memory = m6502.Memory()
+    cpu = m6502.Processor(memory)
+    cpu.reset()
+    cpu.reg_a = value
+    cpu.reg_x = 0x00
+    memory[0xFCE2] = 0xAA
+    cpu.execute(2)
+    assert (
+        cpu.program_counter,
+        cpu.stack_pointer,
+        cpu.cycles,
+        cpu.flag_n,
+        cpu.flag_z,
+        cpu.reg_x,
+    ) == (0xFCE3, 0x01FD, 2, flag_n, flag_z, value)

--- a/tests/test_cpu_ins_tay.py
+++ b/tests/test_cpu_ins_tay.py
@@ -1,0 +1,67 @@
+"""
+TAY - Transfer Accumulator to Y.
+
+Y = A
+
+Copies the current contents of the accumulator into the Y register and sets
+the zero and negative flags as appropriate.
+
+Processor Status after use:
+
++------+-------------------+--------------------------+
+| Flag | Description       | State                    |
++======+===================+==========================+
+|  C   | Carry Flag        | Not affected             |
++------+-------------------+--------------------------+
+|  Z   | Zero Flag         | Set is Y = 0             |
++------+-------------------+--------------------------+
+|  I   | Interrupt Disable | Not affected             |
++------+-------------------+--------------------------+
+|  D   | Decimal Mode Flag | Not affected             |
++------+-------------------+--------------------------+
+|  B   | Break Command     | Not affected             |
++------+-------------------+--------------------------+
+|  V   | Overflow Flag     | Not affected             |
++------+-------------------+--------------------------+
+|  N   | Negative Flag     | Set if bit 7 of Y is set |
++------+-------------------+--------------------------+
+
++-----------------+--------+-------+--------+
+| Addressing Mode | Opcode | Bytes | Cycles |
++=================+========+=======+========+
+| Implied         |  0xA8  |   1   |   2    |
++-----------------+--------+-------+--------+
+
+See also: TYA
+"""
+import pytest
+import m6502
+
+
+@pytest.mark.parametrize(
+    "value, flag_n, flag_z", [
+        (0x0F, False, False),
+        (0x00, False, True),
+        (0xF0, True, False),
+    ])
+def test_cpu_ins_tay_imm(value: int, flag_n: bool, flag_z: bool) -> None:
+    """
+    Transfer Accumulator, Implied.
+
+    return: None
+    """
+    memory = m6502.Memory()
+    cpu = m6502.Processor(memory)
+    cpu.reset()
+    cpu.reg_a = value
+    cpu.reg_y = 0x00
+    memory[0xFCE2] = 0xA8
+    cpu.execute(2)
+    assert (
+        cpu.program_counter,
+        cpu.stack_pointer,
+        cpu.cycles,
+        cpu.flag_n,
+        cpu.flag_z,
+        cpu.reg_y,
+    ) == (0xFCE3, 0x01FD, 2, flag_n, flag_z, value)

--- a/tests/test_cpu_ins_txa.py
+++ b/tests/test_cpu_ins_txa.py
@@ -1,0 +1,67 @@
+"""
+TXA - Transfer Register X to Accumulator.
+
+A = X
+
+Copies the current contents of the X register into the accumulator and sets
+the zero and negative flags as appropriate.
+
+Processor Status after use:
+
++------+-------------------+--------------------------+
+| Flag | Description       | State                    |
++======+===================+==========================+
+|  C   | Carry Flag        | Not affected             |
++------+-------------------+--------------------------+
+|  Z   | Zero Flag         | Set is A = 0             |
++------+-------------------+--------------------------+
+|  I   | Interrupt Disable | Not affected             |
++------+-------------------+--------------------------+
+|  D   | Decimal Mode Flag | Not affected             |
++------+-------------------+--------------------------+
+|  B   | Break Command     | Not affected             |
++------+-------------------+--------------------------+
+|  V   | Overflow Flag     | Not affected             |
++------+-------------------+--------------------------+
+|  N   | Negative Flag     | Set if bit 7 of A is set |
++------+-------------------+--------------------------+
+
++-----------------+--------+-------+--------+
+| Addressing Mode | Opcode | Bytes | Cycles |
++=================+========+=======+========+
+| Implied         |  0x8A  |   1   |   2    |
++-----------------+--------+-------+--------+
+
+See also: TAX
+"""
+import pytest
+import m6502
+
+
+@pytest.mark.parametrize(
+    "value, flag_n, flag_z", [
+        (0x0F, False, False),
+        (0x00, False, True),
+        (0xF0, True, False),
+    ])
+def test_cpu_ins_txa_imm(value: int, flag_n: bool, flag_z: bool) -> None:
+    """
+    Transfer Accumulator, Implied.
+
+    return: None
+    """
+    memory = m6502.Memory()
+    cpu = m6502.Processor(memory)
+    cpu.reset()
+    cpu.reg_a = 0x00
+    cpu.reg_x = value
+    memory[0xFCE2] = 0x8A
+    cpu.execute(2)
+    assert (
+        cpu.program_counter,
+        cpu.stack_pointer,
+        cpu.cycles,
+        cpu.flag_n,
+        cpu.flag_z,
+        cpu.reg_a,
+    ) == (0xFCE3, 0x01FD, 2, flag_n, flag_z, value)

--- a/tests/test_cpu_ins_tya.py
+++ b/tests/test_cpu_ins_tya.py
@@ -1,0 +1,67 @@
+"""
+TYA - Transfer Register Y to Accumulator.
+
+A = Y
+
+Copies the current contents of the Y register into the accumulator and sets
+the zero and negative flags as appropriate.
+
+Processor Status after use:
+
++------+-------------------+--------------------------+
+| Flag | Description       | State                    |
++======+===================+==========================+
+|  C   | Carry Flag        | Not affected             |
++------+-------------------+--------------------------+
+|  Z   | Zero Flag         | Set is A = 0             |
++------+-------------------+--------------------------+
+|  I   | Interrupt Disable | Not affected             |
++------+-------------------+--------------------------+
+|  D   | Decimal Mode Flag | Not affected             |
++------+-------------------+--------------------------+
+|  B   | Break Command     | Not affected             |
++------+-------------------+--------------------------+
+|  V   | Overflow Flag     | Not affected             |
++------+-------------------+--------------------------+
+|  N   | Negative Flag     | Set if bit 7 of A is set |
++------+-------------------+--------------------------+
+
++-----------------+--------+-------+--------+
+| Addressing Mode | Opcode | Bytes | Cycles |
++=================+========+=======+========+
+| Implied         |  0x98  |   1   |   2    |
++-----------------+--------+-------+--------+
+
+See also: TAY
+"""
+import pytest
+import m6502
+
+
+@pytest.mark.parametrize(
+    "value, flag_n, flag_z", [
+        (0x0F, False, False),
+        (0x00, False, True),
+        (0xF0, True, False),
+    ])
+def test_cpu_ins_tya_imm(value: int, flag_n: bool, flag_z: bool) -> None:
+    """
+    Transfer Accumulator, Implied.
+
+    return: None
+    """
+    memory = m6502.Memory()
+    cpu = m6502.Processor(memory)
+    cpu.reset()
+    cpu.reg_a = 0x00
+    cpu.reg_y = value
+    memory[0xFCE2] = 0x98
+    cpu.execute(2)
+    assert (
+        cpu.program_counter,
+        cpu.stack_pointer,
+        cpu.cycles,
+        cpu.flag_n,
+        cpu.flag_z,
+        cpu.reg_a,
+    ) == (0xFCE3, 0x01FD, 2, flag_n, flag_z, value)


### PR DESCRIPTION
The contents of the X and Y registers can be moved to or from the accumulator, setting the negative (N) and zero (Z) flags as appropriate.

- [x] TAX
- [x] TAY
- [x] TXA
- [x] TYA